### PR TITLE
Fix deprecation warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: phenoptr
 Type: Package
 Title: inForm Helper Functions
-Version: 0.3.2
-Date: 2022-01-03
+Version: 0.3.3
+Date: 2023-11-10
 Description: Helper functions for working with inForm data.
 Language: en-US
 biocViews: 
@@ -47,6 +47,8 @@ Authors@R: c(
     person("Kent S", "Johnson", role = c("aut", "cre"),
            email = "kjohnson@akoyabio.com"),
     person("Akoya Biosciences", role="cph"))
+    person("Christian", "Rickert", role="ctb",
+            email = "christian.rickert@cuanschutz.edu"))
 Remotes:
     akoyabio/rtree
 Roxygen: list(markdown = TRUE)

--- a/R/average_counts.R
+++ b/R/average_counts.R
@@ -77,7 +77,8 @@ count_within_batch <- function(base_path, pairs, radius, category=NA,
   all_phenotypes = unique(do.call(c, pairs))
   phenotype_rules = make_phenotype_rules(all_phenotypes, phenotype_rules)
 
-  combos = purrr::cross(list(pair=pairs, category=category))
+  combos = tidyr::expand_grid(category = category, pair = pairs) %>%
+           purrr::pmap(list)
 
   # Loop through all the cell seg data files
   purrr::map_df(files, function(path) {
@@ -165,7 +166,8 @@ count_within_many <- function(csd, pairs, radius, category=NA,
   all_phenotypes = unique(do.call(c, pairs))
   phenotype_rules = make_phenotype_rules(all_phenotypes, phenotype_rules)
 
-  combos = purrr::cross(list(pair=pairs, category=category))
+  combos = tidyr::expand_grid(category = category, pair = pairs) %>%
+           purrr::pmap(list)
 
   # Try to get a name for this field
   field_col = dplyr::if_else('Annotation ID' %in% names(csd),

--- a/R/read_cell_seg_data.R
+++ b/R/read_cell_seg_data.R
@@ -129,7 +129,7 @@ read_cell_seg_data <- function(
   # compatibility with existing client code
   df = df %>%
     dplyr::mutate(dplyr::across(dplyr::starts_with('Phenotype'),
-                                tidyr::replace_na, replace=''))
+                                \(x) tidyr::replace_na(x, replace='')))
 
   # If any of these fields has missing values, the file may be damaged.
   no_na_cols = c("Path", "Sample Name", "Tissue Category", "Phenotype",


### PR DESCRIPTION
Two deprecation warnings led to failed tests. The code has been updated and passes without errors or warnings.